### PR TITLE
Add dataset preparation notebooks

### DIFF
--- a/data/openwebtext/prepare.ipynb
+++ b/data/openwebtext/prepare.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preparing the OpenWebText dataset\n",
+    "\n",
+    "This notebook mirrors `prepare.py` and walks through the steps needed to build the training binary files for nanoGPT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "import tiktoken\n",
+    "from datasets import load_dataset\n",
+    "script_dir = os.getcwd()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the dataset and create train/val splits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_proc = 8\n",
+    "num_proc_load_dataset = num_proc\n",
+    "dataset = load_dataset(\"openwebtext\", num_proc=num_proc_load_dataset)\n",
+    "split_dataset = dataset[\"train\"].train_test_split(test_size=0.0005, seed=2357, shuffle=True)\n",
+    "split_dataset['val'] = split_dataset.pop('test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tokenize using GPT-2 BPE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enc = tiktoken.get_encoding(\"gpt2\")\n",
+    "def process(example):\n",
+    "    ids = enc.encode_ordinary(example['text'])\n",
+    "    ids.append(enc.eot_token)\n",
+    "    return {'ids': ids, 'len': len(ids)}\n",
+    "tokenized = split_dataset.map(\n",
+    "    process,\n",
+    "    remove_columns=['text'],\n",
+    "    desc=\"tokenizing the splits\",\n",
+    "    num_proc=num_proc,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Write the tokens to binary files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for split, dset in tokenized.items():\n",
+    "    arr_len = np.sum(dset['len'], dtype=np.uint64)\n",
+    "    filename = os.path.join(script_dir, f'{split}.bin')\n",
+    "    arr = np.memmap(filename, dtype=np.uint16, mode='w+', shape=(arr_len,))\n",
+    "    total_batches = 1024\n",
+    "    idx = 0\n",
+    "    for batch_idx in tqdm(range(total_batches), desc=f'writing {filename}'):\n",
+    "        batch = dset.shard(num_shards=total_batches, index=batch_idx, contiguous=True).with_format('numpy')\n",
+    "        arr_batch = np.concatenate(batch['ids'])\n",
+    "        arr[idx : idx + len(arr_batch)] = arr_batch\n",
+    "        idx += len(arr_batch)\n",
+    "    arr.flush()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting `train.bin` is about 17GB and `val.bin` around 8.5MB."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/data/shakespeare/prepare.ipynb
+++ b/data/shakespeare/prepare.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preparing the Tiny Shakespeare dataset\n",
+    "\n",
+    "This notebook explains the steps performed in `prepare.py` to create the training files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "import tiktoken\n",
+    "import numpy as np\n",
+    "script_dir = os.getcwd()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_file_path = os.path.join(script_dir, 'input.txt')\n",
+    "if not os.path.exists(input_file_path):\n",
+    "    data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'\n",
+    "    with open(input_file_path, 'w', encoding='utf-8') as f:\n",
+    "        f.write(requests.get(data_url).text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Encode with GPT-2 BPE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(input_file_path, 'r', encoding='utf-8') as f:\n",
+    "    data = f.read()\n",
+    "n = len(data)\n",
+    "train_data = data[:int(n*0.9)]\n",
+    "val_data = data[int(n*0.9):]\n",
+    "enc = tiktoken.get_encoding('gpt2')\n",
+    "train_ids = enc.encode_ordinary(train_data)\n",
+    "val_ids = enc.encode_ordinary(val_data)\n",
+    "print(f'train has {len(train_ids):,} tokens')\n",
+    "print(f'val has {len(val_ids):,} tokens')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export to binary files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_ids = np.array(train_ids, dtype=np.uint16)\n",
+    "val_ids = np.array(val_ids, dtype=np.uint16)\n",
+    "train_ids.tofile(os.path.join(script_dir, 'train.bin'))\n",
+    "val_ids.tofile(os.path.join(script_dir, 'val.bin'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`train.bin` contains 301,966 tokens and `val.bin` contains 36,059 tokens."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/data/shakespeare_char/prepare.ipynb
+++ b/data/shakespeare_char/prepare.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preparing the Tiny Shakespeare dataset (character level)\n",
+    "\n",
+    "This notebook follows `prepare.py` to generate character-level training data for nanoGPT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pickle\n",
+    "import requests\n",
+    "import numpy as np\n",
+    "script_dir = os.getcwd()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_file_path = os.path.join(script_dir, 'input.txt')\n",
+    "if not os.path.exists(input_file_path):\n",
+    "    data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'\n",
+    "    with open(input_file_path, 'w') as f:\n",
+    "        f.write(requests.get(data_url).text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build the character vocabulary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(input_file_path, 'r') as f:\n",
+    "    data = f.read()\n",
+    "chars = sorted(list(set(data)))\n",
+    "vocab_size = len(chars)\n",
+    "stoi = { ch:i for i,ch in enumerate(chars) }\n",
+    "itos = { i:ch for i,ch in enumerate(chars) }\n",
+    "def encode(s):\n",
+    "    return [stoi[c] for c in s]\n",
+    "def decode(l):\n",
+    "    return ''.join([itos[i] for i in l])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create splits and encode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = len(data)\n",
+    "train_data = data[:int(n*0.9)]\n",
+    "val_data = data[int(n*0.9):]\n",
+    "train_ids = encode(train_data)\n",
+    "val_ids = encode(val_data)\n",
+    "print(f'train has {len(train_ids):,} tokens')\n",
+    "print(f'val has {len(val_ids):,} tokens')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Write binary files and save metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_ids = np.array(train_ids, dtype=np.uint16)\n",
+    "val_ids = np.array(val_ids, dtype=np.uint16)\n",
+    "train_ids.tofile(os.path.join(script_dir, 'train.bin'))\n",
+    "val_ids.tofile(os.path.join(script_dir, 'val.bin'))\n",
+    "meta = {\n",
+    "    'vocab_size': vocab_size,\n",
+    "    'itos': itos,\n",
+    "    'stoi': stoi,\n",
+    "}\n",
+    "with open(os.path.join(script_dir, 'meta.pkl'), 'wb') as f:\n",
+    "    pickle.dump(meta, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This process yields `train.bin`, `val.bin` and a `meta.pkl` file containing the vocabulary."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- create Jupyter notebook walkthroughs for dataset preparation scripts
- fix paths to work in notebook environment

## Testing
- `python -m json.tool data/openwebtext/prepare.ipynb`
- `python -m json.tool data/shakespeare/prepare.ipynb`
- `python -m json.tool data/shakespeare_char/prepare.ipynb`
- `python - <<'PY'
import json, ast
for p in ['data/openwebtext/prepare.ipynb','data/shakespeare/prepare.ipynb','data/shakespeare_char/prepare.ipynb']:
    ok=True
    nb=json.load(open(p))
    for i,c in enumerate(nb['cells']):
        if c['cell_type']=='code':
            try: ast.parse(''.join(c['source']))
            except SyntaxError as e:
                print(p,'cell',i,'syntax error',e)
                ok=False; break
    print(p,'syntax ok' if ok else 'syntax error')
PY`